### PR TITLE
docs: add comprehensive Switch transpiler documentation

### DIFF
--- a/docs/lakebridge/docs/overview.mdx
+++ b/docs/lakebridge/docs/overview.mdx
@@ -45,10 +45,11 @@ For migrating your SQL workloads we provide transpilers that can:
  - Translate SQL code from a variety of source platforms to Databricks SQL.
  - Translate some orchestration and ETL code to Databricks SQL.
 
-Internally, Lakebridge can use two different transpilers:
+Internally, Lakebridge can use three different transpilers:
 
  - *BladeBridge*, a mature transpiler that can handle a wide range of source dialects as well as some ETL/orchestration.
  - *Morpheus*, a next-generation transpiler that currently handles a smaller set of dialects, but includes experimental support for dbt.
+ - *Switch*, an LLM-powered transpiler that uses Large Language Models to convert SQL from multiple dialects to Databricks notebooks.
 
 The table below summarizes the source platforms that we currently support:
 
@@ -61,6 +62,8 @@ The table below summarizes the source platforms that we currently support:
 | Snowflake                    |             | &#x2705; | &#x2705; |                   |      &#x2705;      |
 | SQL Server (incl. Synapse)   |  &#x2705;   |          | &#x2705; |                   |                    |
 | Teradata                     |  &#x2705;   |          | &#x2705; |                   |                    |
+
+Additionally, Switch leverages LLMs to handle SQL conversions and can be extended to support various SQL dialects through customizable conversion prompts.
 
 For more information on using the transpiler, refer to the [Transpile][3] documentation.
 

--- a/docs/lakebridge/docs/transpile/overview.mdx
+++ b/docs/lakebridge/docs/transpile/overview.mdx
@@ -88,7 +88,7 @@ It is important to note that the transpiler isn't always able to know whether it
 
 ## Plugins overview
 
-Out of the box, Lakebridge comes with two transpilation plugins: Morpheus and BladeBridge. Each one has its own set of capabilities and levels of guarantee that we describe below.
+Out of the box, Lakebridge comes with three transpilation plugins: Morpheus, BladeBridge, and Switch. Each one has its own set of capabilities and levels of guarantee that we describe below.
 
 ### Morpheus
 
@@ -133,15 +133,31 @@ Whether you're migrating a single job or thousands, BladeBridge delivers predict
 
 More details about the BladeBridge converter [here](/docs/transpile/bladebridge_overview)
 
+### Switch
+
+Switch takes a fundamentally different approach to SQL conversion by leveraging Large Language Models (LLMs). Instead of using parsing and rule-based transformation, Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to understand the intent and semantics of SQL code and generate equivalent Databricks notebooks.
+
+Key characteristics of Switch:
+- **LLM-powered conversion** - Uses Databricks Model Serving endpoints to interpret and convert SQL
+- **Notebook-first output** - Generates Databricks notebooks (.py format) containing Python code with embedded Spark SQL
+- **Batch processing** - Executes as Databricks Jobs, processing multiple files in parallel
+- **Extensible through prompts** - You can create custom YAML prompts to support new SQL dialects or specific conversion requirements
+
+Switch's LLM approach is particularly useful for complex stored procedures and ETL logic. While the generated notebooks may require manual adjustments, they provide a valuable starting point for migration.
+
 ### Supported dialects
 
-| Source Platform              | Converter: BladeBridge | Converter: Morpheus | Output: SQL | Output: SparkSql | Output: PySpark | Other features available |
-|:-----------------------------|:-----------:|:--------:|:---:|:--------:|:-------:|:---------------------------:|
-| DataStage                    |  &#x2705;   |          |     | &#x2705; | &#x2705; |                             |
-| Informatica (Cloud, PC)      |  &#x2705;   |          |     | &#x2705; | &#x2705; |                             |
-| Netezza                      |  &#x2705;   |          | &#x2705; |         |         |                             |
-| Oracle (incl. ADS & Exadata) |  &#x2705;   |          | &#x2705; |         |         |                             |
-| Snowflake                    |             | &#x2705; | &#x2705; |         |         | dbt Repointing (Experimental) |
-| SQL Server (incl. Synapse)   |  &#x2705;   | &#x2705; | &#x2705; |         |         |                             |
-| Teradata                     |  &#x2705;   |          | &#x2705; |         |         |                             |
+| Source Platform              | Converter: BladeBridge | Converter: Morpheus | Converter: Switch[^2] | Output: SQL | Output: SparkSql | Output: PySpark | Other features available |
+|:-----------------------------|:-----------:|:--------:|:--------:|:--------:|:--------:|:-------:|:---------------------------:|
+| DataStage                    |  &#x2705;   |          |          |          | &#x2705; | &#x2705; |                             |
+| Informatica (Cloud, PC)      |  &#x2705;   |          |          |          | &#x2705; | &#x2705; |                             |
+| MySQL                        |             |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| Netezza                      |  &#x2705;   |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| Oracle (incl. ADS & Exadata) |  &#x2705;   |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| PostgreSQL                   |             |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| Redshift                     |             |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| Snowflake                    |             | &#x2705; | &#x2705; | &#x2705; | &#x2705; |         | dbt Repointing (Experimental) |
+| SQL Server (incl. Synapse)   |  &#x2705;   | &#x2705; | &#x2705; | &#x2705; | &#x2705; |         |                             |
+| Teradata                     |  &#x2705;   |          | &#x2705; | &#x2705; | &#x2705; |         |                             |
 
+[^2]: Checkmarks in the Switch column indicate SQL dialects with built-in sample conversion prompts. You can create custom conversion prompts to support additional SQL dialects. For more information, see the [Switch Overview](/docs/transpile/switch_overview).

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -5,56 +5,94 @@ sidebar_position: 4
 
 import CodeBlock from '@theme/CodeBlock';
 
-**Switch** is a Lakebridge transpiler plugin that takes a fundamentally different approach to SQL conversion by leveraging Large Language Models (LLMs). Instead of using parsing and rule-based transformation like traditional transpilers, Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to understand the intent and semantics of SQL code and generate equivalent Databricks notebooks.
+**Switch** is a Lakebridge transpiler plugin that uses Large Language Models (LLMs) to convert SQL code into Databricks notebooks. Switch leverages [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to understand SQL intent and semantics, generating equivalent Python notebooks with Spark SQL.
 
-Switch's LLM-powered approach is particularly effective for complex stored procedures, business logic, and ETL workflows where understanding context and intent matters more than strict syntactic transformation. While the generated notebooks may require manual adjustments, they provide a valuable starting point for migration to Databricks.
+This LLM-powered approach excels at converting complex stored procedures, business logic, and ETL workflows where context and intent matter more than syntactic transformation. While generated notebooks may require manual adjustments, they provide a valuable foundation for Databricks migration.
 
 ---
 
 ## How Switch Works
 
-### LLM-Powered Conversion
-Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) instead of traditional parsing rules. This enables:
+Switch operates through three key components that distinguish it from rule-based transpilers:
 
-- **Semantic Understanding**: Interprets SQL intent and context, not just syntax
-- **Flexible Dialect Support**: Handles proprietary SQL extensions and complex business logic
-- **Custom Prompts**: Extensible through YAML-based prompts for specialized requirements
+### LLM-Powered Semantic Understanding
+Instead of parsing rules, Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to:
+- Interpret SQL intent and business context beyond syntax
+- Handle proprietary SQL extensions and complex logic patterns
+- Support extensible conversion through custom YAML prompts
 
-### Built on Databricks Platform
-Switch leverages native Databricks services:
+### Native Databricks Integration
+Switch runs entirely within the Databricks platform:
+- **Jobs API**: Executes as scalable Databricks Jobs for batch processing
+- **Delta Tables**: Tracks conversion progress with restart capabilities  
+- **Model Serving**: Direct integration with Databricks LLM endpoints
+- **Parallel Processing**: Leverages cluster resources for multiple files
 
-- **Jobs API**: Executes as Databricks Jobs for scalable batch processing
-- **Delta Tables**: Tracks conversion progress and enables restart capabilities  
-- **Model Serving**: Integrates directly with Databricks LLM endpoints
-- **Compute Resources**: Processes multiple files in parallel using cluster resources
+### Flexible Output Formats
+- **Primary Output**: Python notebooks containing Spark SQL
+- **Experimental**: SQL notebook conversion for pure SQL workflows
 
-### Notebook Output
-Switch generates **Python notebooks** containing Spark SQL as the primary output, with an experimental **SQL notebook** conversion feature for teams preferring pure SQL workflows.
+---
+
+## Prerequisites & Requirements
+
+Before installing and using Switch, ensure your Databricks environment meets these requirements:
+
+### Databricks Workspace Setup
+
+**Job Execution Environment**
+- **Job Creation Permission**: Ability to create and manage Databricks Jobs
+  - A Switch job is automatically created during `install-transpile` execution
+- **Compute Access**: Switch creates jobs using serverless job compute by default
+  - If serverless is unavailable, you can modify job configuration in the Databricks workspace to use classic job compute
+
+**Data Storage Requirements**
+- **Catalog Access**: Existing catalog for Switch state management tables
+  - Unity Catalog catalogs (recommended) or Hive metastore catalogs supported
+  - Default catalog name: `remorph`
+- **Schema Access**: Existing schema within the specified catalog
+  - Default schema name: `transpiler`
+- **Table Creation Permission**: `CREATE TABLE` rights on the catalog and schema
+  - Switch creates Delta tables for conversion state and intermediate results
+
+### Model Serving Access
+
+**LLM Endpoint Requirements**
+- **Foundation Model API**: Default endpoint is `databricks-claude-sonnet-4`
+- **Custom Endpoints**: You can configure custom or external model serving endpoints
+- **Token Quota**: Sufficient quota for your conversion workload
+- **Permissions**: Query access to the configured model serving endpoint
+
+### Databricks Runtime (for Classic Job Compute)
+- **Default**: Serverless job compute (no runtime configuration required)
+- **Classic Job Compute**: If using classic clusters instead of serverless:
+  - **Verified Versions**: DBR 14.3 LTS or 15.3 LTS (higher versions likely compatible)
+  - **Compute Type**: Single-node clusters recommended (Photon not required)
 
 ---
 
 ## SQL Dialect Support
 
-Switch includes **built-in sample conversion prompts** for 8 major SQL dialects. You can also create custom conversion prompts to support additional SQL dialects or specialized requirements.
+Switch provides built-in sample conversion prompts for 8 major SQL dialects, with extensibility for custom dialects through YAML configuration.
 
 ### Built-in Sample Conversion Prompts
 
 | SQL Dialect | Source Systems |
 |-------------|----------------|
-| **MySQL** | MySQL, MariaDB, Amazon Aurora MySQL |
+| **MySQL** | MySQL, MariaDB, and MySQL-compatible services (including Amazon Aurora MySQL, RDS, Google Cloud SQL) |
 | **Netezza** | IBM Netezza |
-| **Oracle** | Oracle Database, Oracle Exadata |
-| **PostgreSQL** | PostgreSQL, Amazon Aurora PostgreSQL |
+| **Oracle** | Oracle Database, Oracle Exadata, and Oracle-compatible services (including Amazon RDS) |
+| **PostgreSQL** | PostgreSQL and PostgreSQL-compatible services (including Amazon Aurora PostgreSQL, RDS, Google Cloud SQL) |
 | **Redshift** | Amazon Redshift |
 | **Snowflake** | Snowflake |
 | **Teradata** | Teradata |
-| **T-SQL** | Azure Synapse Analytics, Microsoft SQL Server, Azure SQL Database |
+| **T-SQL** | Microsoft SQL Server, Azure SQL family (Database, Managed Instance, Synapse Analytics), Amazon RDS for SQL Server |
 
 ### Custom Dialect Support
 
-Switch's LLM-based approach allows you to support additional SQL dialects by creating custom YAML conversion prompts. This makes Switch extensible beyond the built-in dialects listed above.
+Switch's LLM-based architecture supports additional SQL dialects through custom YAML conversion prompts, making it extensible beyond built-in options.
 
-For details on creating custom prompts, see the [Advanced Usage](#advanced-usage) section.
+For custom prompt creation, see the [Advanced Usage](#advanced-usage) section.
 
 ---
 
@@ -62,53 +100,59 @@ For details on creating custom prompts, see the [Advanced Usage](#advanced-usage
 
 ### Installation
 
-Switch integrates with Lakebridge's transpiler ecosystem. To install Switch:
+Switch integrates with the Lakebridge transpiler ecosystem:
 
 ```bash
 databricks labs lakebridge install-transpile
 ```
 
-During installation:
+The installation automatically:
 
-1. **Automatic Setup**: Switch is installed along with other transpilers
-2. **Workspace Integration**: A Databricks Job is created in your authenticated workspace  
-3. **Notebook Deployment**: Switch processing notebooks are uploaded to the workspace
-4. **Dialect Configuration**: You can select a SQL dialect during installation or configure it later
+1. **Installs Switch**: Alongside other transpilers
+2. **Creates Databricks Job**: In your authenticated workspace  
+3. **Uploads Notebooks**: Switch processing notebooks to workspace
 
-The installation details are saved in the `custom` section in the transpiler configuration file as shown below:
-- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml` 
+Configuration is saved to:
+- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml`
 - **Windows**: `%USERPROFILE%\.databricks\labs\remorph-transpilers\switch\lib\config.yml`
 
-### Basic CLI Usage
+### CLI Usage
 
-Switch uses the standard Lakebridge transpile command. To specify Switch as your transpiler, use the `--transpiler-config-path` parameter:
+Use the following command to run Switch. Specifying the Switch config file with `--transpiler-config-path` tells Lakebridge to use Switch as the transpiler:
 
 ```bash
-# Basic Switch usage
+# Switch usage
 databricks labs lakebridge transpile \
   --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
-  --input-source /Workspace/Shared/migration/sql \
-  --output-folder /Workspace/Shared/migration/notebooks \
+  --input-source /Workspace/path/to/sql \
+  --output-folder /Workspace/path/to/notebooks \
   --source-dialect snowflake \
-  --catalog-name migration_catalog \
-  --schema-name switch_results
+  --catalog-name your_existing_catalog \
+  --schema-name your_existing_schema
 ```
 
-Switch requires **workspace-based paths** and executes as Databricks Jobs rather than local processing. By default, Switch runs **asynchronously** and returns a job URL for monitoring. You can configure it to wait for completion by updating the `wait_for_completion` setting.
+For advanced configuration options, see [Advanced Configuration](#advanced-configuration) below.
+
+#### Operational Notes
+
+Switch operates differently from other Lakebridge transpilers:
+
+- **Databricks Workspace Paths Required**: Input and output paths must be workspace paths (e.g., `/Workspace/path/to/...`) rather than local file paths
+- **Jobs API Execution**: Switch runs as a Databricks Job in your workspace, not as a local process
+- **Asynchronous by Default**: The command returns immediately with a job URL, allowing you to monitor progress in the Databricks workspace
+- **Monitoring**: Use the returned job URL to track conversion progress and view logs
 
 ### CLI Parameters
-
-The `transpile` command supports these parameters when using Switch:
 
 #### Required Parameters
 - `--transpiler-config-path` - Path to Switch configuration file (identifies Switch as the transpiler)
 - `--input-source` - Workspace path containing SQL files to convert
-- `--output-folder` - Workspace path where generated notebooks will be saved
-- `--source-dialect` - SQL dialect of input files: `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `teradata`, `tsql` (defaults to configuration file setting)
-- `--catalog-name` - Databricks catalog for conversion state tables (default: `remorph`). Must already exist in your workspace.
-- `--schema-name` - Databricks schema for conversion state tables (default: `transpiler`). Must already exist within the specified catalog.
+- `--output-folder` - Workspace path for generated notebooks
+- `--source-dialect` - SQL dialect: `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `teradata`, `tsql`
+- `--catalog-name` - Databricks catalog for state tables (default: `remorph`). Must already exist.
+- `--schema-name` - Databricks schema for state tables (default: `transpiler`). Must already exist.
 
-**Permission Requirements**: The executing user must have `CREATE TABLE` permissions on the specified catalog and schema, as Switch creates Delta tables to track conversion progress and store intermediate results.
+**Permission Requirements**: The user must have `CREATE TABLE` permissions on the specified catalog and schema for Switch's state management and intermediate result tables.
 
 #### Advanced Configuration
 
@@ -129,7 +173,7 @@ Switch provides detailed configuration options that can be set during installati
 
 **Configuration Methods**:
 1. **During Installation**: Configure options when running `databricks labs lakebridge install-transpile`
-2. **Direct File Edit**: Modify the `config.yml` file at the installation path and execute `databricks labs lakebridge transpile`
+2. **Direct File Edit**: Modify the `config.yml` file at the installation path and then execute `databricks labs lakebridge transpile`
 
 ### Job Monitoring
 
@@ -174,7 +218,7 @@ Choose the approach based on your project's complexity, accuracy requirements, a
 #### Effective Switch Usage:
 1. **Start Small**: Begin with representative sample files
 2. **Iterate Prompts**: Refine YAML prompts based on initial results  
-3. **Review and Refine**: Treat Switch output as a good foundation and starting point
+3. **Review and Refine**: Treat output as a solid foundation requiring refinement
 4. **Document Patterns**: Capture successful prompt patterns for reuse
 
 ---

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -5,37 +5,42 @@ sidebar_position: 4
 
 import CodeBlock from '@theme/CodeBlock';
 
-**Switch** is an LLM-powered SQL conversion tool that transforms SQL files from various dialects into Databricks notebooks using Large Language Models.
+**Switch** is a Lakebridge transpiler plugin that takes a fundamentally different approach to SQL conversion by leveraging Large Language Models (LLMs). Instead of using parsing and rule-based transformation like traditional transpilers, Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) to understand the intent and semantics of SQL code and generate equivalent Databricks notebooks.
 
-Unlike transpilers that use deterministic rules, Switch leverages LLMs to understand SQL semantics and generate idiomatic Databricks code.
-
----
-
-## Key Differentiators
-
-### LLM-Based Conversion
-- Uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) endpoints
-- Understands context and intent beyond syntax
-- Generates idiomatic Databricks code
-
-### Batch Processing via Jobs API
-- Executes as Databricks Jobs (not LSP)
-- Processes multiple SQL files in parallel
-- Provides job monitoring and status tracking
-
-### Notebook-First Output
-- Generates Databricks notebooks (.py format) containing Python code with embedded Spark SQL
-- Includes markdown documentation cells
-- Preserves comments in target language
+Switch's LLM-powered approach is particularly effective for complex stored procedures, business logic, and ETL workflows where understanding context and intent matters more than strict syntactic transformation. While the generated notebooks may require manual adjustments, they provide a valuable starting point for migration to Databricks.
 
 ---
 
-## Supported SQL Dialects
+## How Switch Works
 
-Switch supports conversion from 8 major SQL dialects:
+### LLM-Powered Conversion
+Switch uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) instead of traditional parsing rules. This enables:
+
+- **Semantic Understanding**: Interprets SQL intent and context, not just syntax
+- **Flexible Dialect Support**: Handles proprietary SQL extensions and complex business logic
+- **Custom Prompts**: Extensible through YAML-based prompts for specialized requirements
+
+### Built on Databricks Platform
+Switch leverages native Databricks services:
+
+- **Jobs API**: Executes as Databricks Jobs for scalable batch processing
+- **Delta Tables**: Tracks conversion progress and enables restart capabilities  
+- **Model Serving**: Integrates directly with Databricks LLM endpoints
+- **Compute Resources**: Processes multiple files in parallel using cluster resources
+
+### Notebook Output
+Switch generates **Python notebooks** containing Spark SQL as the primary output, with an experimental **SQL notebook** conversion feature for teams preferring pure SQL workflows.
+
+---
+
+## SQL Dialect Support
+
+Switch includes **built-in sample conversion prompts** for 8 major SQL dialects. You can also create custom conversion prompts to support additional SQL dialects or specialized requirements.
+
+### Built-in Sample Conversion Prompts
 
 | SQL Dialect | Source Systems |
-|------------|----------------|
+|-------------|----------------|
 | **MySQL** | MySQL, MariaDB, Amazon Aurora MySQL |
 | **Netezza** | IBM Netezza |
 | **Oracle** | Oracle Database, Oracle Exadata |
@@ -45,26 +50,105 @@ Switch supports conversion from 8 major SQL dialects:
 | **Teradata** | Teradata |
 | **T-SQL** | Azure Synapse Analytics, Microsoft SQL Server, Azure SQL Database |
 
+### Custom Dialect Support
+
+Switch's LLM-based approach allows you to support additional SQL dialects by creating custom YAML conversion prompts. This makes Switch extensible beyond the built-in dialects listed above.
+
+For details on creating custom prompts, see the [Advanced Usage](#advanced-usage) section.
+
 ---
 
-## Conversion Architecture
+## Installation & Usage
 
-### Processing Pipeline
+### Installation
 
-Switch uses a 6-stage pipeline to convert SQL files:
+Switch integrates with Lakebridge's transpiler ecosystem. To install Switch:
 
-1. **Analyze Input Files** - Scans SQL files and calculates token counts
-2. **Convert to Databricks** - Uses LLM to transform SQL to Python/Spark
-3. **Syntax Validation** - Checks Python and embedded SQL syntax
-4. **Error Correction** - Uses LLM to fix any syntax errors
-5. **Cell Splitting** - Organizes code into logical notebook cells
-6. **Export Notebooks** - Writes final Databricks notebooks
+```bash
+databricks labs lakebridge install-transpile
+```
 
-### State Management
+During installation:
 
-- Tracks conversion progress in Delta tables
-- Enables restart and retry capabilities
-- Provides detailed conversion metrics
+1. **Automatic Setup**: Switch is installed along with other transpilers
+2. **Workspace Integration**: A Databricks Job is created in your authenticated workspace  
+3. **Notebook Deployment**: Switch processing notebooks are uploaded to the workspace
+4. **Dialect Configuration**: You can select a SQL dialect during installation or configure it later
+
+The installation details are saved in the `custom` section in the transpiler configuration file as shown below:
+- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml` 
+- **Windows**: `%USERPROFILE%\.databricks\labs\remorph-transpilers\switch\lib\config.yml`
+
+### Basic CLI Usage
+
+Switch uses the standard Lakebridge transpile command. To specify Switch as your transpiler, use the `--transpiler-config-path` parameter:
+
+```bash
+# Basic Switch usage
+databricks labs lakebridge transpile \
+  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
+  --input-source /Workspace/Shared/migration/sql \
+  --output-folder /Workspace/Shared/migration/notebooks \
+  --source-dialect snowflake \
+  --catalog-name migration_catalog \
+  --schema-name switch_results
+```
+
+Switch requires **workspace-based paths** and executes as Databricks Jobs rather than local processing. By default, Switch runs **asynchronously** and returns a job URL for monitoring. You can configure it to wait for completion by updating the `wait_for_completion` setting.
+
+### CLI Parameters
+
+The `transpile` command supports these parameters when using Switch:
+
+#### Required Parameters
+- `--transpiler-config-path` - Path to Switch configuration file (identifies Switch as the transpiler)
+- `--input-source` - Workspace path containing SQL files to convert
+- `--output-folder` - Workspace path where generated notebooks will be saved
+- `--source-dialect` - SQL dialect of input files: `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `teradata`, `tsql` (defaults to configuration file setting)
+- `--catalog-name` - Databricks catalog for conversion state tables (default: `remorph`). Must already exist in your workspace.
+- `--schema-name` - Databricks schema for conversion state tables (default: `transpiler`). Must already exist within the specified catalog.
+
+**Permission Requirements**: The executing user must have `CREATE TABLE` permissions on the specified catalog and schema, as Switch creates Delta tables to track conversion progress and store intermediate results.
+
+#### Advanced Configuration
+
+Switch provides detailed configuration options that can be set during installation or by editing the `config.yml` file directly:
+
+| Parameter | Description | Default Value | Available Options |
+|-----------|-------------|---------------|-------------------|
+| `endpoint_name` | Model serving endpoint name | `databricks-claude-sonnet-4` | Any valid endpoint name |
+| `token_count_threshold` | Maximum tokens per file for processing | `20000` | Any positive integer |
+| `concurrency` | Number of parallel LLM requests | `4` | Any positive integer |
+| `comment_lang` | Language for generated comments | `English` | `English`, `Japanese`, `Chinese`, `Spanish`, `French`, `German` |
+| `max_fix_attempts` | Maximum syntax error fix attempts | `1` | Any positive integer |
+| `log_level` | Logging verbosity level | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `conversion_prompt_yaml` | Custom conversion prompt YAML file path | `<none>` | Full workspace path to YAML file |
+| `existing_result_table` | Existing result table to reuse | `<none>` | Full table name (`catalog.schema.table`) |
+| `sql_output_dir` | (Experimental) Directory for SQL notebooks | `<none>` | Full workspace path |
+| `wait_for_completion` | Wait for job completion (synchronous mode) | `false` | `true`, `false` |
+
+**Configuration Methods**:
+1. **During Installation**: Configure options when running `databricks labs lakebridge install-transpile`
+2. **Direct File Edit**: Modify the `config.yml` file at the installation path and execute `databricks labs lakebridge transpile`
+
+### Job Monitoring
+
+After executing the transpile command, Switch runs **asynchronously by default** and returns job execution details in JSON format:
+
+```json
+{
+  "transpiler": "switch",
+  "job_id": 12345,
+  "run_id": 67890,
+  "run_url": "https://your-workspace.databricks.com/#job/12345/run/67890"
+}
+```
+
+Access the `run_url` to monitor job progress in your Databricks workspace.
+
+**Job Execution Modes**:
+- **Asynchronous (default)**: Command returns immediately with monitoring URL
+- **Synchronous**: Set `wait_for_completion: true` in transpiler config to wait for job completion
 
 ---
 
@@ -73,37 +157,270 @@ Switch uses a 6-stage pipeline to convert SQL files:
 ### When to Use Switch
 
 Switch's LLM-based approach makes it particularly suitable for:
-- Complex stored procedures and ETL logic
-- SQL dialects not covered by LSP-based transpilers (you can add support through custom YAML prompts)
+- **Complex stored procedures and ETL logic** where understanding business intent is crucial
+- **SQL dialects not yet covered by other transpilers** — Switch allows you to add support through custom YAML prompts
 
-### When to Use LSP-based Transpilers
+### When to Use Other Transpilers
 
-⚡ **Consider LSP transpilers for:**
-- Real-time, interactive conversion
-- Deterministic output requirements
-- Sub-second response requirements
+Morpheus and BladeBridge are particularly suitable for:
+- **Interactive conversion** with immediate processing
+- **Deterministic output requirements** with guaranteed syntax equivalence
+- **High-volume processing** with faster throughput than Switch
 
----
+Choose the approach based on your project's complexity, accuracy requirements, and processing time constraints.
 
-## Integration with Lakebridge
+### Success Patterns
 
-Switch integrates seamlessly with Lakebridge through:
-
-- Standard `install-transpiler` command
-- Unified `transpile` CLI interface
-- PyPI-based distribution
-- Workspace-based file management
-
-See the [Transpile Guide](./index.mdx#switch-specific-usage) for detailed usage instructions.
+#### Effective Switch Usage:
+1. **Start Small**: Begin with representative sample files
+2. **Iterate Prompts**: Refine YAML prompts based on initial results  
+3. **Review and Refine**: Treat Switch output as a good foundation and starting point
+4. **Document Patterns**: Capture successful prompt patterns for reuse
 
 ---
 
-## Advanced Features
+## Databricks Implementation Details
+
+When you run Switch via the CLI, it executes as Databricks Jobs using a sophisticated multi-stage processing pipeline. This section covers the internal architecture and configuration options.
+
+### Processing Architecture
+
+Switch implements a 6-stage conversion pipeline through specialized Databricks notebooks:
+
+| Stage | Notebook | Purpose |
+|-------|----------|---------|
+| **1** | `01_analyze_input_files` | Analyzes input SQL files, calculates token counts, saves results to Delta table |
+| **2** | `02_convert_sql_to_databricks` | Converts SQL to Python/Spark using LLM, updates result table |  
+| **3** | `03_01_static_syntax_check` | Performs syntax validation on generated Python and embedded SQL |
+| **4** | `03_02_fix_syntax_error` | Automatically fixes syntax errors using LLM |
+| **5** | `04_split_cells` | Organizes code into logical notebook cells |
+| **6** | `05_export_to_databricks_notebooks` | Creates final Databricks notebooks |
+
+#### Optional Processing
+
+- **`06_convert_to_sql_notebooks`** (Experimental) - Generates SQL notebook format
+- **`11_adjust_conversion_targets`** - Allows reprocessing specific files
+
+### Conversion Flow
+
+```mermaid
+flowchart TD
+    input[Input SQL Files] -->|Input| analyze[[01_analyze_input_files]]
+    analyze <-->|Read & Write| conversionTable[Conversion Result Table]
+
+    conversionTable <-->|Read & Write| convert[[02_convert_sql_to_databricks]]
+    convert -.->|Use| endpoint[Model Serving Endpoint]
+    convert -.->|Refer| prompts["Conversion Prompt YAML<br/>(SQL Dialect Specific)"]
+
+    conversionTable <-->|Read & Write| validate[[03_01_static_syntax_check]]
+
+    conversionTable <-->|Read & Write| fixErrors[[03_02_fix_syntax_error]]
+    fixErrors -.->|Use| endpoint
+
+    conversionTable <-->|Read & Write| splitCells[[04_split_cells]]
+
+    conversionTable -->|Input| export[[05_export_to_databricks_notebooks]]
+    export -->|Output| notebooks[Converted Databricks Notebooks]
+
+    conversionTable <-->|Read & Write| adjust[[11_adjust_conversion_targets]]
+
+    %% Styling
+    classDef process fill:#E6E6FA,stroke:#333,stroke-width:2px;
+    class analyze,convert,validate,fixErrors,splitCells,adjust,export process;
+    classDef data fill:#E0F0E0,stroke:#333,stroke-width:2px;
+    class input,conversionTable,notebooks data;
+    classDef external fill:#FFF0DB,stroke:#333,stroke-width:2px;
+    class endpoint,prompts external;
+```
+
+### State Management
+
+Switch uses Delta tables for robust state management:
+
+- **Progress Tracking**: Records conversion status for each input file
+- **Restart Capability**: Failed jobs can resume from last successful stage
+- **Metrics Collection**: Detailed token usage and processing time data
+- **Error Tracking**: Comprehensive error logging for debugging
+
+### Notebook-Level Configuration
+
+While CLI parameters control basic settings, Switch notebooks accept detailed configuration:
+
+#### Core Processing Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `input_dir` | Directory containing SQL files | From CLI `--input-source` |
+| `endpoint_name` | Model serving endpoint | `databricks-claude-3-7-sonnet` |
+| `result_catalog` | Catalog for tracking tables | From CLI `--catalog-name` |
+| `result_schema` | Schema for tracking tables | From CLI `--schema-name` |
+| `token_count_threshold` | Max tokens per file | `20000` |
+
+#### LLM Processing Settings
+
+| Parameter | Description | Default |  
+|-----------|-------------|---------|
+| `sql_dialect` | Input SQL dialect | From CLI `--source-dialect` |
+| `comment_lang` | Generated comment language | `English` |
+| `concurrency` | Parallel LLM requests | `4` |
+| `request_params` | LLM request parameters (JSON) | `{}` |
+
+#### Conversion Result Table
+
+Switch creates Delta tables with this schema:
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `input_file_number` | int | Unique file identifier |
+| `input_file_path` | string | Source file path |
+| `input_file_token_count_without_sql_comments` | int | Processed token count |
+| `is_conversion_target` | boolean | Whether file should be processed |
+| `result_content` | string | Generated notebook content |
+| `result_total_tokens` | int | LLM tokens consumed |
+| `result_timestamp` | timestamp | Processing completion time |
+| `result_error` | string | Any errors encountered |
+
+**Table Naming**: `{catalog}.{schema}.conversion_targets_{YYYYMMDDHHmm}`
+
+### Model Requirements
+
+#### Supported LLM Endpoints
+
+**Primary Recommendation**:
+- **Claude 3.7 Sonnet** (`databricks-claude-3-7-sonnet`) - Best performance for complex SQL
+- **Extended Thinking Mode**: Enable with `{"max_tokens": 64000, "thinking": {"type": "enabled", "budget_tokens": 16000}}`
+
+**Azure Alternatives**:
+- **Azure OpenAI o1** (2024-12-17) - 200K context, 100K output  
+- **Azure OpenAI o3-mini** (2025-01-31) - 200K context, 100K output
+
+**Other Compatible Models**:
+- Claude 3.5 Sonnet, GPT-4o, Llama 3.3 70B Instruct
+
+#### Token Management
+
+- **Threshold Logic**: Files exceeding `token_count_threshold` are skipped
+- **Token Counting**: Performed after removing SQL comments and whitespace
+- **Recommended Limits**: 
+  - Normal mode: 20,000 tokens
+  - Extended thinking: 8,000 tokens
+
+### Infrastructure Requirements  
+
+#### Databricks Permissions
+
+Switch requires the following permissions for the executing user:
+
+**Workspace Permissions**:
+- **Read/Write Access**: To specified input and output workspace paths
+- **Job Management**: `CAN_MANAGE` or `CAN_VIEW` permissions on created Switch jobs
+
+**Catalog and Schema Permissions**:
+- **Catalog Access**: `USE CATALOG` permission on the specified catalog (default: `remorph`)
+- **Schema Access**: `USE SCHEMA` permission on the specified schema (default: `transpiler`)
+- **Table Creation**: `CREATE TABLE` permission to create conversion tracking Delta tables
+- **Table Management**: `SELECT`, `INSERT`, `UPDATE` permissions on tracking tables for state management
+
+**Model Serving Permissions**:
+- **Endpoint Access**: Permission to query the configured LLM model serving endpoint
+- **Token Usage**: Adequate token quota for your model serving endpoint
+
+**Important**: Both the catalog and schema must **already exist** before running Switch. Switch will not create catalogs or schemas automatically.
+
+#### Compute Resources
+- **Cluster Types**: Serverless or classic compute clusters
+- **Recommended**: Single-node clusters (Photon not required)
+- **Runtime**: DBR 14.3 LTS or 15.3 LTS verified
+
+---
+
+## Advanced Usage
 
 ### Customizable Prompts
-- You can create custom YAML prompts to support new SQL dialects
-- Dialect-specific conversion rules
-- Few-shot learning examples
+
+Switch supports creating custom conversion prompts for new SQL dialects or specialized conversion requirements.
+
+#### Default YAML Files by Dialect
+
+Switch provides built-in YAML configuration files for each supported SQL dialect:
+
+| SQL Dialect | Source System Example | Default YAML File |
+|-------------|----------------------|-------------------|
+| `mysql` | MySQL / MariaDB / Amazon Aurora MySQL | `mysql_to_databricks_notebook.yml` |
+| `netezza` | IBM Netezza | `netezza_to_databricks_notebook.yml` |
+| `oracle` | Oracle Database / Oracle Exadata | `oracle_to_databricks_notebook.yml` |
+| `postgresql` | PostgreSQL / Amazon Aurora PostgreSQL | `postgresql_to_databricks_notebook.yml` |
+| `redshift` | Amazon Redshift | `redshift_to_databricks_notebook.yml` |
+| `snowflake` | Snowflake | `snowflake_to_databricks_notebook.yml` |
+| `teradata` | Teradata | `teradata_to_databricks_notebook.yml` |
+| `tsql` | Azure Synapse Analytics / Microsoft SQL Server / Azure SQL Database | `tsql_to_databricks_notebook.yml` |
+
+#### Creating Custom Conversion Prompts
+
+To create a custom conversion prompt:
+
+1. **Create a YAML file** with the required structure
+2. **Place it in your Databricks workspace**
+3. **Specify the full path** in the `conversion_prompt_yaml` parameter
+
+Custom conversion prompts require two main sections:
+
+##### Required Structure
+
+```yaml
+system_message: |
+  Convert SQL code to Python code that runs on Databricks according to the following instructions:
+
+  # Input and Output
+  - Input: A single SQL file containing one or multiple T-SQL statements
+  - Output: Python code with Python comments (in {comment_lang}) explaining the code
+
+  ${common_python_instructions_and_guidelines}
+
+  # Additional Instructions
+  1. Convert SQL queries to spark.sql() format
+  2. Add clear Python comments explaining the code
+  3. Use DataFrame operations instead of loops when possible
+  4. Handle errors using try-except blocks
+
+few_shots:
+- role: user
+  content: |
+    SELECT name, age
+    FROM users
+    WHERE active = 1;
+- role: assistant
+  content: |
+    # Get names and ages of active users
+    active_users = spark.sql("""
+        SELECT name, age
+        FROM users
+        WHERE active = 1
+    """)
+    display(active_users)
+```
+
+##### Key Elements
+
+**`system_message` Section**:
+- Clear explanation of the conversion purpose
+- Definition of input and output formats
+- Additional instructions for specific conversions
+- Comment language specification (`{comment_lang}` is automatically replaced)
+- Reference to common instructions (`${common_python_instructions_and_guidelines}`)
+
+**`few_shots` Section** (Optional but recommended):
+- Include examples ranging from simple to complex cases
+- Each example demonstrates specific patterns for LLM understanding
+- Shows typical conversion patterns for your SQL dialect
+
+#### Best Practices for Custom Prompts
+
+1. **Start with existing YAML files** as templates for your custom dialects
+2. **Include specific dialect features** that differ from standard SQL
+3. **Provide comprehensive examples** covering edge cases in your SQL dialect
+4. **Test thoroughly** with representative SQL files before large-scale usage
+5. **Iterate and refine** based on conversion results
 
 ### Multi-Language Comments
 - Generate comments in various languages
@@ -115,90 +432,79 @@ See the [Transpile Guide](./index.mdx#switch-specific-usage) for detailed usage 
 - Maintains Spark SQL compatibility
 - Enable with `--sql-output-dir`
 
----
+### Troubleshooting and Best Practices
 
-## Technical Requirements
+#### Re-converting Specific Files
 
-### Model Serving Endpoint
-- Requires access to Databricks Model Serving
-- Default: `databricks-claude-sonnet-4`
-- Configurable via `--endpoint-name`
+If conversion results are not satisfactory, you can re-convert specific files:
 
-### Workspace Permissions
-- Read access to input SQL files
-- Write access to output directory
-- Job creation permissions
-- Delta table creation in specified catalog/schema
+1. **Mark files for re-conversion**: Use the `11_adjust_conversion_targets` notebook to set the `is_conversion_target` field to `True` for files you want to re-convert
+2. **Re-run conversion**: Execute the `02_convert_sql_to_databricks` notebook and subsequent processes. Only files marked as `is_conversion_target` with `True` will be re-converted
+3. **Add randomness**: To get different results on each run, set the `temperature` in `request_params` to above 0.5 (if supported by your model)
 
----
+#### Common Issues and Solutions
 
-## Installation & Usage
+##### Files Not Converting (Status: "Not converted")
 
-### Installation
+**Cause**: Input files exceed the token count threshold
+**Solutions**:
+- Split large input files into smaller, more manageable parts
+- Increase the `token_count_threshold` parameter if your LLM model can handle larger inputs
+- Consider using extended thinking mode for Claude 3.7 Sonnet with reduced threshold (8,000 tokens)
 
-When you run `databricks labs lakebridge install-transpiler`:
+##### Conversion with Errors (Status: "Converted with errors")
 
-1. Switch is automatically installed along with other transpilers
-2. A Databricks Job is created in your authenticated workspace
-3. Switch notebooks are uploaded to the workspace
-4. During configuration, you can select a SQL dialect from Switch's supported dialects, or configure it later
+**Cause**: Files were converted but contain syntax errors
+**Solutions**:
+- Review syntax error messages at the bottom of output notebooks
+- Manually fix errors in the converted notebooks
+- Increase `max_fix_attempts` for more automatic error correction attempts
+- Verify your model serving endpoint supports the required features
 
-The installation details (including job URL) are saved in the transpiler configuration file:
-- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml`
-- **Windows**: `%USERPROFILE%\.databricks\labs\remorph-transpilers\switch\lib\config.yml`
+##### Export Failures (Status: "Not exported")
 
-The installation process prepares Switch to run as Databricks Jobs for batch SQL conversion.
+**Cause**: Converted content exceeds 10MB size limit
+**Solutions**:
+- Review and reduce the size of input SQL files
+- Split complex procedures into multiple smaller files
+- Check for excessive code generation or repetitive patterns
 
-### Basic Usage
+#### Token Management Best Practices
 
-Switch requires workspace-based paths and executes via Databricks Jobs. Use the `--transpiler-config-path` to specify Switch:
+##### Understanding Token Counting
 
-```bash
-# Minimal execution
-databricks labs lakebridge transpile \
-  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
-  --input-source /Workspace/Users/myuser/sql_source \
-  --output-folder /Workspace/Users/myuser/notebooks \
-  --catalog-name my_catalog \
-  --schema-name switch_results
+- Token count is calculated **after** removing SQL comments and extra whitespace
+- Generated notebooks typically contain more tokens than input SQL due to:
+  - Added comments and documentation
+  - Code formatting and indentation
+  - Python wrapper code around SQL statements
 
-# With SQL dialect specification
-databricks labs lakebridge transpile \
-  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
-  --input-source /Workspace/Shared/migration/sql \
-  --output-folder /Workspace/Shared/migration/notebooks \
-  --source-dialect snowflake \
-  --catalog-name migration_catalog \
-  --schema-name switch_results
-```
+##### Recommended Thresholds by Model
 
-### Parameters Reference
+| Model | Recommended `token_count_threshold` | Notes |
+|-------|-----------------------------------|-------|
+| Claude 3.7 Sonnet (Normal) | 20,000 tokens | Default value, tested up to 60,000 tokens |
+| Claude 3.7 Sonnet (Extended Thinking) | 8,000 tokens | Higher values may result in errors |
+| Other models (o1, o3-mini, etc.) | ~20,000 tokens | Test in your environment for optimal values |
 
-The `transpile` command accepts the following parameters:
+##### File Size Management
 
-#### Standard Transpile Parameters
-- `--transpiler-config-path` - Path to Switch config file (required to use Switch)
-- `--input-source` - Workspace path containing SQL files (required)
-- `--output-folder` - Workspace path for generated notebooks (required)
-- `--source-dialect` - Source SQL dialect: `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `teradata`, `tsql` (optional, default from config)
-- `--catalog-name` - Databricks catalog for result table (optional, default: `remorph`)
-- `--schema-name` - Databricks schema for result table (optional, default: `transpiler`)
+- For files exceeding token limits, consider logical splitting points:
+  - Separate stored procedures into individual files
+  - Split by functional modules or business domains
+  - Maintain referential integrity across split files
 
-#### Switch-Specific Behavior
-When Switch is detected (via transpiler-config-path), it uses these parameters to configure a Databricks Job execution. Switch internally manages additional parameters like:
-- Model serving endpoint configuration
-- Token count thresholds
-- Concurrency settings
-- Language preferences for comments
+#### Performance Optimization
 
-These are configured during installation or via the Switch config.yml file.
+##### Concurrency Settings
 
-### Job Monitoring
+- Default `concurrency` of 4 works well for most use cases
+- Increase concurrency for faster processing (model endpoint permitting)
+- Monitor model serving endpoint for rate limiting or throttling
 
-Switch returns a job run URL for monitoring progress:
+##### Model Selection Strategy
 
-```
-Switch job submitted successfully.
-Job Run URL: https://your-workspace.databricks.com/#job/12345/run/67890
-Monitor job progress at the provided URL.
-```
+1. **Start with Claude 3.7 Sonnet** (Foundation Model API) for easiest setup
+2. **Use Extended Thinking Mode** for complex stored procedures and business logic
+3. **Consider Azure alternatives** only if organizational policies require them
+4. **Test token thresholds** in your specific environment before large-scale conversions

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -1,0 +1,204 @@
+---
+title: Switch Overview
+sidebar_position: 4
+---
+
+import CodeBlock from '@theme/CodeBlock';
+
+**Switch** is an LLM-powered SQL conversion tool that transforms SQL files from various dialects into Databricks notebooks using Large Language Models.
+
+Unlike transpilers that use deterministic rules, Switch leverages LLMs to understand SQL semantics and generate idiomatic Databricks code.
+
+---
+
+## Key Differentiators
+
+### LLM-Based Conversion
+- Uses [Mosaic AI Model Serving](https://docs.databricks.com/aws/en/machine-learning/model-serving/) endpoints
+- Understands context and intent beyond syntax
+- Generates idiomatic Databricks code
+
+### Batch Processing via Jobs API
+- Executes as Databricks Jobs (not LSP)
+- Processes multiple SQL files in parallel
+- Provides job monitoring and status tracking
+
+### Notebook-First Output
+- Generates Databricks notebooks (.py format) containing Python code with embedded Spark SQL
+- Includes markdown documentation cells
+- Preserves comments in target language
+
+---
+
+## Supported SQL Dialects
+
+Switch supports conversion from 8 major SQL dialects:
+
+| SQL Dialect | Source Systems |
+|------------|----------------|
+| **MySQL** | MySQL, MariaDB, Amazon Aurora MySQL |
+| **Netezza** | IBM Netezza |
+| **Oracle** | Oracle Database, Oracle Exadata |
+| **PostgreSQL** | PostgreSQL, Amazon Aurora PostgreSQL |
+| **Redshift** | Amazon Redshift |
+| **Snowflake** | Snowflake |
+| **Teradata** | Teradata |
+| **T-SQL** | Azure Synapse Analytics, Microsoft SQL Server, Azure SQL Database |
+
+---
+
+## Conversion Architecture
+
+### Processing Pipeline
+
+Switch uses a 6-stage pipeline to convert SQL files:
+
+1. **Analyze Input Files** - Scans SQL files and calculates token counts
+2. **Convert to Databricks** - Uses LLM to transform SQL to Python/Spark
+3. **Syntax Validation** - Checks Python and embedded SQL syntax
+4. **Error Correction** - Uses LLM to fix any syntax errors
+5. **Cell Splitting** - Organizes code into logical notebook cells
+6. **Export Notebooks** - Writes final Databricks notebooks
+
+### State Management
+
+- Tracks conversion progress in Delta tables
+- Enables restart and retry capabilities
+- Provides detailed conversion metrics
+
+---
+
+## Use Cases
+
+### When to Use Switch
+
+Switch's LLM-based approach makes it particularly suitable for:
+- Complex stored procedures and ETL logic
+- SQL dialects not covered by LSP-based transpilers (you can add support through custom YAML prompts)
+
+### When to Use LSP-based Transpilers
+
+⚡ **Consider LSP transpilers for:**
+- Real-time, interactive conversion
+- Deterministic output requirements
+- Sub-second response requirements
+
+---
+
+## Integration with Lakebridge
+
+Switch integrates seamlessly with Lakebridge through:
+
+- Standard `install-transpiler` command
+- Unified `transpile` CLI interface
+- PyPI-based distribution
+- Workspace-based file management
+
+See the [Transpile Guide](./index.mdx#switch-specific-usage) for detailed usage instructions.
+
+---
+
+## Advanced Features
+
+### Customizable Prompts
+- You can create custom YAML prompts to support new SQL dialects
+- Dialect-specific conversion rules
+- Few-shot learning examples
+
+### Multi-Language Comments
+- Generate comments in various languages
+- Preserves original documentation intent
+- Configurable via `--comment-lang`
+
+### Experimental SQL Notebooks
+- Optional conversion to SQL notebook format
+- Maintains Spark SQL compatibility
+- Enable with `--sql-output-dir`
+
+---
+
+## Technical Requirements
+
+### Model Serving Endpoint
+- Requires access to Databricks Model Serving
+- Default: `databricks-claude-sonnet-4`
+- Configurable via `--endpoint-name`
+
+### Workspace Permissions
+- Read access to input SQL files
+- Write access to output directory
+- Job creation permissions
+- Delta table creation in specified catalog/schema
+
+---
+
+## Installation & Usage
+
+### Installation
+
+When you run `databricks labs lakebridge install-transpiler`:
+
+1. Switch is automatically installed along with other transpilers
+2. A Databricks Job is created in your authenticated workspace
+3. Switch notebooks are uploaded to the workspace
+4. During configuration, you can select a SQL dialect from Switch's supported dialects, or configure it later
+
+The installation details (including job URL) are saved in the transpiler configuration file:
+- **macOS/Linux**: `~/.databricks/labs/remorph-transpilers/switch/lib/config.yml`
+- **Windows**: `%USERPROFILE%\.databricks\labs\remorph-transpilers\switch\lib\config.yml`
+
+The installation process prepares Switch to run as Databricks Jobs for batch SQL conversion.
+
+### Basic Usage
+
+Switch requires workspace-based paths and executes via Databricks Jobs. Use the `--transpiler-config-path` to specify Switch:
+
+```bash
+# Minimal execution
+databricks labs lakebridge transpile \
+  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
+  --input-source /Workspace/Users/myuser/sql_source \
+  --output-folder /Workspace/Users/myuser/notebooks \
+  --catalog-name my_catalog \
+  --schema-name switch_results
+
+# With SQL dialect specification
+databricks labs lakebridge transpile \
+  --transpiler-config-path ~/.databricks/labs/remorph-transpilers/switch/lib/config.yml \
+  --input-source /Workspace/Shared/migration/sql \
+  --output-folder /Workspace/Shared/migration/notebooks \
+  --source-dialect snowflake \
+  --catalog-name migration_catalog \
+  --schema-name switch_results
+```
+
+### Parameters Reference
+
+The `transpile` command accepts the following parameters:
+
+#### Standard Transpile Parameters
+- `--transpiler-config-path` - Path to Switch config file (required to use Switch)
+- `--input-source` - Workspace path containing SQL files (required)
+- `--output-folder` - Workspace path for generated notebooks (required)
+- `--source-dialect` - Source SQL dialect: `mysql`, `netezza`, `oracle`, `postgresql`, `redshift`, `snowflake`, `teradata`, `tsql` (optional, default from config)
+- `--catalog-name` - Databricks catalog for result table (optional, default: `remorph`)
+- `--schema-name` - Databricks schema for result table (optional, default: `transpiler`)
+
+#### Switch-Specific Behavior
+When Switch is detected (via transpiler-config-path), it uses these parameters to configure a Databricks Job execution. Switch internally manages additional parameters like:
+- Model serving endpoint configuration
+- Token count thresholds
+- Concurrency settings
+- Language preferences for comments
+
+These are configured during installation or via the Switch config.yml file.
+
+### Job Monitoring
+
+Switch returns a job run URL for monitoring progress:
+
+```
+Switch job submitted successfully.
+Job Run URL: https://your-workspace.databricks.com/#job/12345/run/67890
+Monitor job progress at the provided URL.
+```

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -229,23 +229,16 @@ When you run Switch via the CLI, it executes as Databricks Jobs using a sophisti
 
 ### Processing Architecture
 
-Switch implements a 6-stage conversion pipeline through specialized Databricks notebooks:
+Switch executes as a Databricks Job that runs the main orchestration notebook (`00_main`), which coordinates a 6-stage conversion pipeline:
 
-| Stage | Notebook | Purpose |
-|-------|----------|---------|
-| **1** | `01_analyze_input_files` | Analyzes input SQL files, calculates token counts, saves results to Delta table |
-| **2** | `02_convert_sql_to_databricks` | Converts SQL to Python/Spark using LLM, updates result table |  
-| **3** | `03_01_static_syntax_check` | Performs syntax validation on generated Python and embedded SQL |
-| **4** | `03_02_fix_syntax_error` | Automatically fixes syntax errors using LLM |
-| **5** | `04_split_cells` | Organizes code into logical notebook cells |
-| **6** | `05_export_to_databricks_notebooks` | Creates final Databricks notebooks |
+#### Main Orchestration
+The **`00_main`** notebook serves as the entry point when Switch is executed via Databricks Jobs API. It:
+- Validates all input parameters from the job configuration
+- Executes each processing stage in sequence using `dbutils.notebook.run()`
+- Tracks overall progress and handles stage-level failures
+- Returns the final conversion status to the job runner
 
-#### Optional Processing
-
-- **`06_convert_to_sql_notebooks`** (Experimental) - Generates SQL notebook format
-- **`11_adjust_conversion_targets`** - Allows reprocessing specific files
-
-### Conversion Flow
+#### Conversion Flow
 
 ```mermaid
 flowchart TD
@@ -266,115 +259,154 @@ flowchart TD
     conversionTable -->|Input| export[[05_export_to_databricks_notebooks]]
     export -->|Output| notebooks[Converted Databricks Notebooks]
 
-    conversionTable <-->|Read & Write| adjust[[11_adjust_conversion_targets]]
-
     %% Styling
     classDef process fill:#E6E6FA,stroke:#333,stroke-width:2px;
-    class analyze,convert,validate,fixErrors,splitCells,adjust,export process;
+    class analyze,convert,validate,fixErrors,splitCells,export process;
     classDef data fill:#E0F0E0,stroke:#333,stroke-width:2px;
     class input,conversionTable,notebooks data;
     classDef external fill:#FFF0DB,stroke:#333,stroke-width:2px;
     class endpoint,prompts external;
 ```
 
+The conversion pipeline consists of 6 core stages plus 1 optional stage, each implemented as a separate Databricks notebook. The following sections provide detailed explanations of each processing stage shown in the flow above.
+
+##### Stage 1: File Analysis
+The pipeline begins by scanning your input directory for SQL files. It removes SQL comments to get accurate token counts using model-specific tokenizers (Claude uses ~3.4 characters per token, OpenAI uses tiktoken). Files exceeding the `token_count_threshold` are excluded from conversion. All metadata is stored in a timestamped Delta table for tracking.
+
+##### Stage 2: SQL Conversion
+The system loads dialect-specific YAML prompts (or your custom prompt) and sends SQL content to the configured model serving endpoint. Multiple files are processed concurrently (default: 4) for efficiency. The LLM transforms SQL code into Python code with `spark.sql()` calls, preserving business logic while adapting to Databricks patterns.
+
+##### Stage 3: Syntax Validation
+Before proceeding, all generated code undergoes rigorous validation. Python syntax is checked using `ast.parse()`, while SQL statements within `spark.sql()` calls are validated using Spark's `EXPLAIN` command. Any errors are recorded in the result table without modifying the code.
+
+##### Stage 4: Error Correction
+If syntax errors are detected, this stage attempts automatic fixes. It sends the error context back to the LLM, which suggests corrections. The process repeats up to `max_fix_attempts` times (default: 1). This stage only runs when errors exist from the previous validation.
+
+##### Stage 5: Cell Organization
+Raw converted code is transformed into a well-structured notebook. The system analyzes code flow and dependencies, splitting at logical boundaries like imports, function definitions, and major SQL operations. Markdown cells are added for documentation and readability.
+
+##### Stage 6: Notebook Export
+The final stage creates Databricks-compatible `.py` notebooks in your output directory. Each notebook includes metadata, source file references, and any syntax check results as comments. The system handles files up to 10MB and preserves your directory structure.
+
+##### Stage 7: SQL Notebook Conversion (Optional)
+When `sql_output_dir` is specified, this experimental stage uses the model serving endpoint to convert Python notebooks into SQL notebook format with Databricks SQL syntax. This is useful for teams preferring SQL-only workflows, though some Python logic may be lost in translation.
+
+### Parameter Mapping
+
+When Switch executes as a Databricks Job, CLI parameters are mapped to notebook parameters:
+
+| CLI Parameter | Notebook Parameter | Description |
+|---------------|-------------------|-------------|
+| `--input-source` | `input_dir` | Directory containing SQL files |
+| `--output-folder` | `output_dir` | Directory for generated notebooks |
+| `--catalog-name` | `result_catalog` | Catalog for tracking tables |
+| `--schema-name` | `result_schema` | Schema for tracking tables |
+| `--source-dialect` | `sql_dialect` | Input SQL dialect |
+| `--transpiler-config-path` | (config file) | Loads additional parameters from Switch config |
+
+Additional parameters are configured through the Switch config file (see [Advanced Configuration](#advanced-configuration) above).
+
 ### State Management
 
-Switch uses Delta tables for robust state management:
+Switch uses a Delta table to track conversion progress and results. Each conversion job creates a timestamped table: `{catalog}.{schema}.conversion_targets_{YYYYMMDDHHmm}`
 
-- **Progress Tracking**: Records conversion status for each input file
-- **Restart Capability**: Failed jobs can resume from last successful stage
-- **Metrics Collection**: Detailed token usage and processing time data
-- **Error Tracking**: Comprehensive error logging for debugging
+The table stores input file information (path, content, token counts), conversion results (generated notebooks, token usage, processing time), error details when conversions fail, and syntax check results from validation stages. This allows you to monitor which files were processed successfully and investigate any issues that occurred during conversion.
 
-### Notebook-Level Configuration
+#### Conversion Result Table Schema
 
-While CLI parameters control basic settings, Switch notebooks accept detailed configuration:
+Switch creates Delta tables with the following complete schema:
 
-#### Core Processing Parameters
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `input_dir` | Directory containing SQL files | From CLI `--input-source` |
-| `endpoint_name` | Model serving endpoint | `databricks-claude-3-7-sonnet` |
-| `result_catalog` | Catalog for tracking tables | From CLI `--catalog-name` |
-| `result_schema` | Schema for tracking tables | From CLI `--schema-name` |
-| `token_count_threshold` | Max tokens per file | `20000` |
-
-#### LLM Processing Settings
-
-| Parameter | Description | Default |  
-|-----------|-------------|---------|
-| `sql_dialect` | Input SQL dialect | From CLI `--source-dialect` |
-| `comment_lang` | Generated comment language | `English` |
-| `concurrency` | Parallel LLM requests | `4` |
-| `request_params` | LLM request parameters (JSON) | `{}` |
-
-#### Conversion Result Table
-
-Switch creates Delta tables with this schema:
-
-| Column | Type | Purpose |
-|--------|------|---------|
-| `input_file_number` | int | Unique file identifier |
-| `input_file_path` | string | Source file path |
-| `input_file_token_count_without_sql_comments` | int | Processed token count |
-| `is_conversion_target` | boolean | Whether file should be processed |
-| `result_content` | string | Generated notebook content |
-| `result_total_tokens` | int | LLM tokens consumed |
-| `result_timestamp` | timestamp | Processing completion time |
-| `result_error` | string | Any errors encountered |
-
-**Table Naming**: `{catalog}.{schema}.conversion_targets_{YYYYMMDDHHmm}`
+| Column | Type | Description |
+|--------|------|-------------|
+| `input_file_number` | int | Unique integer identifier for each input file (starts from 1) |
+| `input_file_path` | string | Full path to the input file |
+| `input_file_encoding` | string | Detected encoding of the input file (e.g., UTF-8) |
+| `tokenizer_type` | string | Type of tokenizer used (claude or openai) |
+| `tokenizer_model` | string | Specific tokenizer model/encoding used |
+| `input_file_token_count` | int | Total number of tokens in the input file |
+| `input_file_token_count_without_sql_comments` | int | Token count excluding SQL comments |
+| `input_file_content` | string | Entire content of the input file |
+| `input_file_content_without_sql_comments` | string | Content excluding SQL comments |
+| `is_conversion_target` | boolean | Whether file should be processed (updated during conversion) |
+| `model_serving_endpoint_for_conversion` | string | Model endpoint used for conversion |
+| `model_serving_endpoint_for_fix` | string | Model endpoint used for syntax error fixing |
+| `request_params_for_conversion` | string | Conversion request parameters in JSON format |
+| `request_params_for_fix` | string | Fix request parameters in JSON format |
+| `result_content` | string | Generated notebook content (initially null) |
+| `result_prompt_tokens` | int | Number of prompt tokens used (initially null) |
+| `result_completion_tokens` | int | Number of completion tokens generated (initially null) |
+| `result_total_tokens` | int | Total tokens used (prompt + completion, initially null) |
+| `result_processing_time_seconds` | float | Processing time in seconds (initially null) |
+| `result_timestamp` | timestamp | UTC timestamp when processing completed (initially null) |
+| `result_error` | string | Any conversion errors encountered (initially null) |
+| `result_python_parse_error` | string | Python syntax errors found using ast.parse |
+| `result_extracted_sqls` | array<string> | SQL statements extracted from Python code (initially null) |
+| `result_sql_parse_errors` | array<string> | SQL syntax errors found using EXPLAIN (initially null) |
 
 ### Model Requirements
 
 #### Supported LLM Endpoints
 
+Switch works with LLMs that have large context windows and strong code comprehension capabilities. Databricks Foundation Model APIs provide the simplest setup, while external models offer additional flexibility for organizational requirements.
+
 **Primary Recommendation**:
-- **Claude 3.7 Sonnet** (`databricks-claude-3-7-sonnet`) - Best performance for complex SQL
-- **Extended Thinking Mode**: Enable with `{"max_tokens": 64000, "thinking": {"type": "enabled", "budget_tokens": 16000}}`
+Currently, the latest Claude models available through Foundation Model APIs show the best performance for understanding complex code patterns and business logic in SQL-to-notebook conversion.
 
-**Azure Alternatives**:
-- **Azure OpenAI o1** (2024-12-17) - 200K context, 100K output  
-- **Azure OpenAI o3-mini** (2025-01-31) - 200K context, 100K output
+For complex stored procedures and intricate business logic, Claude's extended thinking mode can significantly improve conversion accuracy. This mode allows the model to reason through complex transformations more thoroughly, though it increases processing time and token usage. To enable extended thinking mode, configure the `request_params` parameter (example values):
+```json
+{"max_tokens": 64000, "thinking": {"type": "enabled", "budget_tokens": 16000}}
+```
 
-**Other Compatible Models**:
-- Claude 3.5 Sonnet, GPT-4o, Llama 3.3 70B Instruct
+Other capable models are also supported through both Foundation Model APIs and external models.
+
+**External Models**:
+For organizations with specific requirements (such as Azure-only policies, custom compliance needs, or high-throughput processing), Switch supports external models through external model serving endpoints. External models offer benefits including:
+- **Throughput Control**: Configure dedicated capacity for consistent performance
+- **Organizational Compliance**: Meet specific cloud or vendor requirements
+- **Cost Management**: Optimize costs for large-scale processing
+- **Higher Concurrency**: Scale beyond Foundation Model API limitations
+
+**Choosing Between Options**:
+- **Foundation Model APIs**: Best for getting started, smaller workloads, and standard use cases
+- **External Models**: Recommended for large-scale processing, organizational constraints, or when higher concurrency is needed
 
 #### Token Management
 
-- **Threshold Logic**: Files exceeding `token_count_threshold` are skipped
-- **Token Counting**: Performed after removing SQL comments and whitespace
-- **Recommended Limits**: 
-  - Normal mode: 20,000 tokens
-  - Extended thinking: 8,000 tokens
+LLMs have limits on how much text they can process at once. Switch uses a simple threshold approach:
 
-### Infrastructure Requirements  
+**How it works:**
+- Stage 1 analyzes each SQL file and counts tokens (after removing comments and compressing multiple spaces into a single space)
+- Files with token count ≤ `token_count_threshold` are marked for conversion
+- Files exceeding the threshold are skipped with status "Not converted"
 
-#### Databricks Permissions
+**Token counting approach:**
+- Claude models: Character-based estimation (~3.4 characters per token)
+- Other models: Uses tiktoken library with o200k_base encoding
+- Rough guideline: 20,000 tokens ≈ 50,000 single-byte characters
 
-Switch requires the following permissions for the executing user:
+**Recommended approach:**
+- Default threshold: 20,000 tokens (example value based on stability testing)
+- For complex transformations with extended thinking: Consider lower thresholds (e.g., 8,000 tokens)
+- Optimal values may vary by model and environment - test in your specific setup for best results
 
-**Workspace Permissions**:
-- **Read/Write Access**: To specified input and output workspace paths
-- **Job Management**: `CAN_MANAGE` or `CAN_VIEW` permissions on created Switch jobs
+**Managing large files:**
+If your SQL files exceed the threshold, consider logical splitting points:
+- Separate stored procedures into individual files
+- Split by functional modules or business domains
+- Maintain referential integrity across split files
 
-**Catalog and Schema Permissions**:
-- **Catalog Access**: `USE CATALOG` permission on the specified catalog (default: `remorph`)
-- **Schema Access**: `USE SCHEMA` permission on the specified schema (default: `transpiler`)
-- **Table Creation**: `CREATE TABLE` permission to create conversion tracking Delta tables
-- **Table Management**: `SELECT`, `INSERT`, `UPDATE` permissions on tracking tables for state management
+#### Performance Optimization
 
-**Model Serving Permissions**:
-- **Endpoint Access**: Permission to query the configured LLM model serving endpoint
-- **Token Usage**: Adequate token quota for your model serving endpoint
+**Concurrency Settings:**
+- **Default concurrency**: Set to 4 to accommodate limitations with some Foundation Model API endpoints
+- **Scaling for large workloads**: For processing many files simultaneously, consider:
+  - **Provisioned Throughput**: Deploy dedicated Foundation Model API capacity with guaranteed throughput
+  - **External Models**: Configure external endpoints with higher rate limits
+  - **Increased concurrency**: Adjust the `concurrency` parameter based on endpoint capacity
 
-**Important**: Both the catalog and schema must **already exist** before running Switch. Switch will not create catalogs or schemas automatically.
-
-#### Compute Resources
-- **Cluster Types**: Serverless or classic compute clusters
-- **Recommended**: Single-node clusters (Photon not required)
-- **Runtime**: DBR 14.3 LTS or 15.3 LTS verified
+**Monitoring:**
+- Watch for rate limiting or throttling responses from model endpoints
+- Consider enabling [Inference Tables](https://docs.databricks.com/aws/en/machine-learning/model-serving/inference-tables) to automatically capture requests and responses for detailed monitoring and debugging
 
 ---
 
@@ -383,21 +415,6 @@ Switch requires the following permissions for the executing user:
 ### Customizable Prompts
 
 Switch supports creating custom conversion prompts for new SQL dialects or specialized conversion requirements.
-
-#### Default YAML Files by Dialect
-
-Switch provides built-in YAML configuration files for each supported SQL dialect:
-
-| SQL Dialect | Source System Example | Default YAML File |
-|-------------|----------------------|-------------------|
-| `mysql` | MySQL / MariaDB / Amazon Aurora MySQL | `mysql_to_databricks_notebook.yml` |
-| `netezza` | IBM Netezza | `netezza_to_databricks_notebook.yml` |
-| `oracle` | Oracle Database / Oracle Exadata | `oracle_to_databricks_notebook.yml` |
-| `postgresql` | PostgreSQL / Amazon Aurora PostgreSQL | `postgresql_to_databricks_notebook.yml` |
-| `redshift` | Amazon Redshift | `redshift_to_databricks_notebook.yml` |
-| `snowflake` | Snowflake | `snowflake_to_databricks_notebook.yml` |
-| `teradata` | Teradata | `teradata_to_databricks_notebook.yml` |
-| `tsql` | Azure Synapse Analytics / Microsoft SQL Server / Azure SQL Database | `tsql_to_databricks_notebook.yml` |
 
 #### Creating Custom Conversion Prompts
 
@@ -466,37 +483,36 @@ few_shots:
 4. **Test thoroughly** with representative SQL files before large-scale usage
 5. **Iterate and refine** based on conversion results
 
-### Multi-Language Comments
-- Generate comments in various languages
-- Preserves original documentation intent
-- Configurable via `--comment-lang`
+#### Reference: Built-in YAML Files
 
-### Experimental SQL Notebooks
-- Optional conversion to SQL notebook format
-- Maintains Spark SQL compatibility
-- Enable with `--sql-output-dir`
+Switch provides built-in YAML configuration files for each of the 8 supported SQL dialects. When creating custom prompts, these built-in configurations serve as excellent starting points - even for supported dialects, customizing the default prompts based on your specific input patterns can significantly improve conversion accuracy.
 
-### Troubleshooting and Best Practices
+**Location**: You can find example YAML files in the `pyscripts/conversion_prompt_yaml/` directory within the same workspace folder as the main Switch notebook (`00_main`). These files demonstrate the proper structure and provide dialect-specific examples that you can adapt for your custom requirements.
 
-#### Re-converting Specific Files
+### Conversion Results and Troubleshooting
 
-If conversion results are not satisfactory, you can re-convert specific files:
+#### Understanding Conversion Results
 
-1. **Mark files for re-conversion**: Use the `11_adjust_conversion_targets` notebook to set the `is_conversion_target` field to `True` for files you want to re-convert
-2. **Re-run conversion**: Execute the `02_convert_sql_to_databricks` notebook and subsequent processes. Only files marked as `is_conversion_target` with `True` will be re-converted
-3. **Add randomness**: To get different results on each run, set the `temperature` in `request_params` to above 0.5 (if supported by your model)
+After your Switch job completes, review the conversion results displayed at the end of the `00_main` notebook execution. The results table shows the status of each input file:
 
-#### Common Issues and Solutions
+- **Successfully converted files**: Ready to use as Databricks notebooks
+- **Files requiring attention**: May need manual review or re-processing
 
-##### Files Not Converting (Status: "Not converted")
+If you encounter files that didn't convert successfully, here are the most common issues and their solutions:
+
+#### Files Not Converting (Status: "Not converted")
+
+These files were skipped during the conversion process, typically because they're too large for the model to process effectively.
 
 **Cause**: Input files exceed the token count threshold
 **Solutions**:
 - Split large input files into smaller, more manageable parts
 - Increase the `token_count_threshold` parameter if your LLM model can handle larger inputs
-- Consider using extended thinking mode for Claude 3.7 Sonnet with reduced threshold (8,000 tokens)
+- For models with extended thinking capabilities, consider using lower thresholds with that mode enabled
 
-##### Conversion with Errors (Status: "Converted with errors")
+#### Conversion with Errors (Status: "Converted with errors")
+
+These files were successfully processed by the LLM but the generated code contains syntax errors that need to be addressed.
 
 **Cause**: Files were converted but contain syntax errors
 **Solutions**:
@@ -505,50 +521,12 @@ If conversion results are not satisfactory, you can re-convert specific files:
 - Increase `max_fix_attempts` for more automatic error correction attempts
 - Verify your model serving endpoint supports the required features
 
-##### Export Failures (Status: "Not exported")
+#### Export Failures (Status: "Not exported")
+
+These files were converted successfully but couldn't be exported as notebooks due to size limitations.
 
 **Cause**: Converted content exceeds 10MB size limit
 **Solutions**:
 - Review and reduce the size of input SQL files
 - Split complex procedures into multiple smaller files
 - Check for excessive code generation or repetitive patterns
-
-#### Token Management Best Practices
-
-##### Understanding Token Counting
-
-- Token count is calculated **after** removing SQL comments and extra whitespace
-- Generated notebooks typically contain more tokens than input SQL due to:
-  - Added comments and documentation
-  - Code formatting and indentation
-  - Python wrapper code around SQL statements
-
-##### Recommended Thresholds by Model
-
-| Model | Recommended `token_count_threshold` | Notes |
-|-------|-----------------------------------|-------|
-| Claude 3.7 Sonnet (Normal) | 20,000 tokens | Default value, tested up to 60,000 tokens |
-| Claude 3.7 Sonnet (Extended Thinking) | 8,000 tokens | Higher values may result in errors |
-| Other models (o1, o3-mini, etc.) | ~20,000 tokens | Test in your environment for optimal values |
-
-##### File Size Management
-
-- For files exceeding token limits, consider logical splitting points:
-  - Separate stored procedures into individual files
-  - Split by functional modules or business domains
-  - Maintain referential integrity across split files
-
-#### Performance Optimization
-
-##### Concurrency Settings
-
-- Default `concurrency` of 4 works well for most use cases
-- Increase concurrency for faster processing (model endpoint permitting)
-- Monitor model serving endpoint for rate limiting or throttling
-
-##### Model Selection Strategy
-
-1. **Start with Claude 3.7 Sonnet** (Foundation Model API) for easiest setup
-2. **Use Extended Thinking Mode** for complex stored procedures and business logic
-3. **Consider Azure alternatives** only if organizational policies require them
-4. **Test token thresholds** in your specific environment before large-scale conversions

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -308,7 +308,7 @@ Additional parameters are configured through the Switch config file (see the [Ad
 
 ### State Management
 
-Switch uses a Delta table to track conversion progress and results. Each conversion job creates a timestamped table: `{catalog}.{schema}.conversion_targets_{YYYYMMDDHHmm}`
+Switch uses a Delta table to track conversion progress and results. Each conversion job creates a timestamped table: `{catalog}.{schema}.lakebridge_switch_{YYYYMMDDHHmm}`
 
 The table stores input file information (path, content, token counts), conversion results (generated notebooks, token usage, processing time), error details when conversions fail, and syntax check results from validation stages. This allows you to monitor which files were processed successfully and investigate any issues that occurred during conversion.
 

--- a/docs/lakebridge/docs/transpile/switch_overview.mdx
+++ b/docs/lakebridge/docs/transpile/switch_overview.mdx
@@ -131,7 +131,7 @@ databricks labs lakebridge transpile \
   --schema-name your_existing_schema
 ```
 
-For advanced configuration options, see [Advanced Configuration](#advanced-configuration) below.
+For advanced configuration options, see the [Advanced Configuration](#advanced-configuration) section below.
 
 #### Operational Notes
 
@@ -304,7 +304,7 @@ When Switch executes as a Databricks Job, CLI parameters are mapped to notebook 
 | `--source-dialect` | `sql_dialect` | Input SQL dialect |
 | `--transpiler-config-path` | (config file) | Loads additional parameters from Switch config |
 
-Additional parameters are configured through the Switch config file (see [Advanced Configuration](#advanced-configuration) above).
+Additional parameters are configured through the Switch config file (see the [Advanced Configuration](#advanced-configuration) section above).
 
 ### State Management
 


### PR DESCRIPTION
## Summary
Add complete user documentation for Switch transpiler integration in Lakebridge, including comprehensive usage guide, configuration reference, and troubleshooting information.
## Changes
- **New Documentation**: Create `docs/lakebridge/docs/transpile/switch_overview.mdx` with complete Switch transpiler guide
- **Navigation Updates**: Add Switch transpiler links to overview pages for discoverability
- **User Experience**: Provide step-by-step installation, configuration, and usage instructions
## Documentation Coverage
- Switch transpiler overview and architecture
- Installation via `lakebridge install-transpiler`
- Configuration management and parameter reference
- CLI usage examples for all 8 supported SQL dialects
- Troubleshooting guide for common issues
- Integration with existing Lakebridge workflow
## Test Plan
- [x] Documentation builds successfully in Docusaurus
- [x] All internal links and navigation work correctly
- [x] Code examples and commands are accurate
- [x] Formatting and structure are consistent with existing docs
## Related Work
Part of Switch transpiler integration (Phase 2A) - completes user-facing documentation requirements.